### PR TITLE
Add support for multiple wiremock versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+
+language: c
+
+services:
+  - docker
+
+before_install:
+  - docker info
+  - docker build -t ekino/wiremock:$WM_VERSION ./$WM_VERSION
+
+env:
+  - WM_VERSION=1
+  - WM_VERSION=2
+
+script:
+  - docker run -d --name wiremock -v $(readlink -f files):/wiremock/__files -v $(readlink -f mappings):/wiremock/mappings ekino/wiremock:$WM_VERSION
+  - sleep 2
+  - docker logs wiremock
+  - docker exec wiremock curl -sS http://localhost:8080/hello
+  - docker rm -f wiremock

--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -1,10 +1,13 @@
 # --- WIREMOCK ---
 
-FROM ekino/java7
+FROM anapsix/alpine-java:8
 MAINTAINER fronton@ekino.com
 
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+
 ENV WM_PACKAGE wiremock
-ENV WM_VERSION 1.55
+ARG WM_VERSION=1.55
 
 RUN mkdir /$WM_PACKAGE
 WORKDIR /$WM_PACKAGE

--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -1,0 +1,18 @@
+# --- WIREMOCK ---
+
+FROM anapsix/alpine-java:8
+MAINTAINER benitte@ekino.com
+
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+
+ENV WM_PACKAGE wiremock
+ARG WM_VERSION=2.1.11
+
+RUN mkdir /$WM_PACKAGE
+WORKDIR /$WM_PACKAGE
+RUN curl -sSL -o $WM_PACKAGE.jar https://repo1.maven.org/maven2/com/github/tomakehurst/$WM_PACKAGE-standalone/$WM_VERSION/$WM_PACKAGE-standalone-$WM_VERSION.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java","-jar","wiremock.jar"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ekino/wiremock
 
-[![Circle CI](https://circleci.com/gh/ekino/docker-wiremock.svg?style=svg)](https://circleci.com/gh/ekino/docker-wiremock)
+[![Travis CI][travis-image]][travis-url]
 
 ## Description
 
@@ -27,4 +27,7 @@ docker run -d \
 # use it
 curl http://127.0.0.1/hello
 ```
+
+[travis-image]: https://img.shields.io/travis/ekino/docker-wiremock.svg?style=flat-square
+[travis-url]: https://travis-ci.org/ekino/docker-wiremock
 


### PR DESCRIPTION
- Add support for for NW_VERSION build arg
- Add a basic travis-ci setup
- Update wiremock url to use the new repo (wiremock-standalone VS wiremock).
- Use [alpine-java](https://hub.docker.com/r/anapsix/alpine-java/) to reduce image size
