### PR TITLE
Allow additional Wiremock arguments to be passed via WM_ARGS env variable

### DIFF
--- a/2.7.1/Dockerfile
+++ b/2.7.1/Dockerfile
@@ -15,4 +15,5 @@ RUN curl -sSL -o $WM_PACKAGE.jar https://repo1.maven.org/maven2/com/github/tomak
 
 EXPOSE 8080
 
-ENTRYPOINT ["java","-jar","wiremock.jar"]
+ENTRYPOINT java -jar wiremock.jar $WM_ARGS
+


### PR DESCRIPTION
This allows additional arguments to be passed to the underlying Wiremock server as per Wiremock's [Running Standalone Docs](http://wiremock.org/docs/running-standalone/) e.g. setting WM_ARGS to --verbose will enable verbose mode.